### PR TITLE
Adds server check to support Next.js

### DIFF
--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -8,8 +8,8 @@ export const useMergeLink = (config: UseMergeLinkProps): UseMergeLinkResponse =>
     checkForExisting: true,
   });
   const [isReady, setIsReady] = useState(false);
-
-  const isReadyForInitialization = !!window.MergeLink && !loading && !error;
+  const isServer = (typeof window !== 'undefined')
+  const isReadyForInitialization = !isServer && !!window.MergeLink && !loading && !error;
 
   useEffect(() => {
     if (isReadyForInitialization && window.MergeLink) {

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -8,7 +8,7 @@ export const useMergeLink = (config: UseMergeLinkProps): UseMergeLinkResponse =>
     checkForExisting: true,
   });
   const [isReady, setIsReady] = useState(false);
-  const isServer = (typeof window === 'undefined')
+  const isServer = (typeof window === 'undefined');
   const isReadyForInitialization = !isServer && !!window.MergeLink && !loading && !error;
 
   useEffect(() => {

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -8,7 +8,7 @@ export const useMergeLink = (config: UseMergeLinkProps): UseMergeLinkResponse =>
     checkForExisting: true,
   });
   const [isReady, setIsReady] = useState(false);
-  const isServer = (typeof window !== 'undefined')
+  const isServer = (typeof window === 'undefined')
   const isReadyForInitialization = !isServer && !!window.MergeLink && !loading && !error;
 
   useEffect(() => {


### PR DESCRIPTION
## Description of the change

Problem: The `useMergeLink` hook doesn't work out of the box for Next.js. This is because Next.js attempts to run the code on the server and at that point the window is not defined. The variable `isReadyForInitialization` does not account for this case and throws an error because `window` is currently undefined. Can be tested by running code with Next.js.

I've added the following line and updated the check in `isReadyForInitialization`:

```
const isServer = (typeof window === 'undefined');  
const isReadyForInitialization = !isServer && !!window.MergeLink && !loading && !error;
```




## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> All PRs at Merge must be backed by an Asana ticket (except Develop -> Master PRs). Create one here, and then replace this line with the link. https://app.asana.com/0/1198991781422585/list

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
