### PR TITLE
fix(types): UseMergeLinkProps onExit is optional

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -13,7 +13,7 @@ export interface TenantConfig {
 export interface UseMergeLinkProps {
   linkToken: string;
   tenantConfig?: TenantConfig
-  onExit: () => void;
+  onExit?: () => void;
   onSuccess: (publicTokenID: string) => void;
 }
 


### PR DESCRIPTION
## Problem

Bumping from 1.3.1 to 1.3.2 brings in [previously missing types](https://github.com/merge-api/react-merge-link/commit/bb98db067cff1dc89bd613e4eea583276184cee1). Those types fail in my repo. It looks like it would fail in the [getting started](https://merge.dev/docs/guides/merge-link/get-started/) example too.

```
const { open, isReady } = useMergeLink({
  linkToken: "ADD_GENERATED_LINK_TOKEN",
  onSuccess,
});
```
> Property 'onExit' is missing in type '{ linkToken: string; onSuccess: () => void; }' but required in type 'UseMergeLinkProps'.

## Description of the change

This PR makes `onExit` property for `useMergeLink` optional.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
