### PR TITLE
Add shouldSendTokenOnSuccessfulLink and bump major

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -8,13 +8,18 @@ export interface MergeLink {
 }
 
 export interface TenantConfig {
-  apiBaseURL?: string
+  apiBaseURL?: string;
 }
 export interface UseMergeLinkProps {
   linkToken: string;
-  tenantConfig?: TenantConfig
-  onExit?: () => void;
+  tenantConfig?: TenantConfig;
   onSuccess: (publicTokenID: string) => void;
+  onExit?: () => void;
+  /**
+   * Make Link call `onSuccess` immediately after an account has been successfully linked instead of after the user closes the Link modal.
+   * Defaults to `true` as of v2.0.0. The default is `false` in prior versions.
+   */
+  shouldSendTokenOnSuccessfulLink?: boolean | undefined;
 }
 
 export interface InitializeProps extends UseMergeLinkProps {
@@ -25,7 +30,7 @@ export type UseMergeLinkResponse = {
   open: (config: UseMergeLinkProps) => void;
   isReady: boolean;
   error: ErrorEvent | null;
-}
+};
 
 declare global {
   interface Window {

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -2,19 +2,24 @@ import { useCallback, useEffect, useState } from 'react';
 import useScript from './useScriptHook';
 import { UseMergeLinkProps, UseMergeLinkResponse } from './types';
 
-export const useMergeLink = (config: UseMergeLinkProps): UseMergeLinkResponse => {
+export const useMergeLink = ({
+  shouldSendTokenOnSuccessfulLink = true,
+  ...config
+}: UseMergeLinkProps): UseMergeLinkResponse => {
   const [loading, error] = useScript({
     src: 'https://cdn.merge.dev/initialize.js',
     checkForExisting: true,
   });
   const [isReady, setIsReady] = useState(false);
-  const isServer = (typeof window === 'undefined');
-  const isReadyForInitialization = !isServer && !!window.MergeLink && !loading && !error;
+  const isServer = typeof window === 'undefined';
+  const isReadyForInitialization =
+    !isServer && !!window.MergeLink && !loading && !error;
 
   useEffect(() => {
     if (isReadyForInitialization && window.MergeLink) {
       window.MergeLink.initialize({
         ...config,
+        shouldSendTokenOnSuccessfulLink,
         onReady: () => setIsReady(true),
       });
     }


### PR DESCRIPTION
## Description of the change

* Add `shouldSendTokenOnSuccessfulLink` to `UseMergeLinkProps` with a default value of `true`.
* Bump major version due to change in default behavior.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/merge-api/react-merge-link/issues/21