### PR TITLE
Fix type for open and bump patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -27,7 +27,7 @@ export interface InitializeProps extends UseMergeLinkProps {
 }
 
 export type UseMergeLinkResponse = {
-  open: (config: UseMergeLinkProps) => void;
+  open: () => void;
   isReady: boolean;
   error: ErrorEvent | null;
 };


### PR DESCRIPTION
## Description of the change

We unintentionally changed the type of `UseMergeLinkResponse`'s `open` property in v1.3.2. `open` doesn't do anything with the `config` parameter passed into it, so there's no behavioral change here, just a typing error.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)