### PR TITLE
Add magic link tracking

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -12,7 +12,7 @@ export interface TenantConfig {
 }
 export interface UseMergeLinkProps {
   linkToken: string;
-  tenantConfig?: TenantConfig
+  tenantConfig?: TenantConfig;
   isMagicLink?: boolean;
   onSuccess: (publicTokenID: string) => void;
   onExit?: () => void;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -12,7 +12,8 @@ export interface TenantConfig {
 }
 export interface UseMergeLinkProps {
   linkToken: string;
-  tenantConfig?: TenantConfig;
+  tenantConfig?: TenantConfig
+  isMagicLink?: boolean;
   onSuccess: (publicTokenID: string) => void;
   onExit?: () => void;
   /**


### PR DESCRIPTION
## Description of the change

> Add isMagicLink optional boolean to allow magic-merge-link to pass flag through to merge-link. We then use this in merge-backend to track which accounts were created using magic link.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://app.asana.com/0/1201896759935915/1202602162259506/f

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
