### PR TITLE
Add linkToken validation before initialize 

### DIFF
--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -16,7 +16,7 @@ export const useMergeLink = ({
     !isServer && !!window.MergeLink && !loading && !error;
 
   useEffect(() => {
-    if (isReadyForInitialization && window.MergeLink) {
+    if (isReadyForInitialization && window.MergeLink && config.linkToken) {
       window.MergeLink.initialize({
         ...config,
         shouldSendTokenOnSuccessfulLink,


### PR DESCRIPTION
Add linkToken validation before initialize the call

## Description of the change

> Adding this validation allows to for example get the linkToken from another fetch in the front end and just after we have the token we initialize the call

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Example

```jsx
const token = useFetchTokenFromBackEnd(); // this hook return token= null until have the value from a fetch call

const { open, isReady } = useMergeLink({
      linkToken: token, // Token fetched from the backend in another hook
      onSuccess
});
```