### PR TITLE
Add additionalInfo parameter to onSuccess callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,8 +1,15 @@
+export type AdditionalSuccessfulLinkInfo = {
+  isTokenForOtherPreexistingLinkedAccount?: boolean;
+};
+
 export interface MergeLink {
   initialize: (config: InitializeProps) => void;
   update: (config: {
     linkToken: string;
-    onSuccess: (publicTokenID: string) => void;
+    onSuccess: (
+      publicToken: string,
+      additionalInfo?: AdditionalSuccessfulLinkInfo
+    ) => void;
   }) => void;
   openLink: (config: UseMergeLinkProps) => void;
 }
@@ -13,7 +20,10 @@ export interface TenantConfig {
 export interface UseMergeLinkProps {
   linkToken: string;
   tenantConfig?: TenantConfig;
-  onSuccess: (publicTokenID: string) => void;
+  onSuccess: (
+    publicToken: string,
+    additionalInfo?: AdditionalSuccessfulLinkInfo
+  ) => void;
   onExit?: () => void;
   /**
    * Make Link call `onSuccess` immediately after an account has been successfully linked instead of after the user closes the Link modal.


### PR DESCRIPTION
## Description of the change

When [your org's setting](https://app.merge.dev/configuration/integrations/settings) is configured in the dashboard like this: ![image](https://user-images.githubusercontent.com/9922914/184041324-dd0d181e-8120-4b00-b0db-031ae914ea82.png)

the new property on the optional second parameter indicates whether the public token for the linked account is for a preexisting duplicate of the new linked account instead of for the new linked account, since we didn't actually create the new linked account.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)