### PR TITLE
Don't call window.MergeLink.initialize if linkToken is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -18,7 +18,7 @@ export interface TenantConfig {
   apiBaseURL?: string;
 }
 export interface UseMergeLinkProps {
-  linkToken: string;
+  linkToken?: string | undefined;
   tenantConfig?: TenantConfig;
   onSuccess: (
     publicToken: string,
@@ -33,7 +33,8 @@ export interface UseMergeLinkProps {
 }
 
 export interface InitializeProps extends UseMergeLinkProps {
-  onReady: () => void;
+  linkToken: string;
+  onReady?: () => void;
 }
 
 export type UseMergeLinkResponse = {

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 import useScript from 'react-script-hook';
-import { UseMergeLinkProps, UseMergeLinkResponse } from './types';
+import {
+  InitializeProps,
+  UseMergeLinkProps,
+  UseMergeLinkResponse,
+} from './types';
+
+const isLinkTokenDefined = (
+  config: UseMergeLinkProps
+): config is InitializeProps => config?.linkToken !== undefined;
 
 export const useMergeLink = ({
   shouldSendTokenOnSuccessfulLink = true,
@@ -13,7 +21,11 @@ export const useMergeLink = ({
   const [isReady, setIsReady] = useState(false);
   const isServer = typeof window === 'undefined';
   const isReadyForInitialization =
-    !isServer && !!window.MergeLink && !loading && !error;
+    !isServer &&
+    !!window.MergeLink &&
+    !loading &&
+    !error &&
+    isLinkTokenDefined(config);
 
   useEffect(() => {
     if (isReadyForInitialization && window.MergeLink) {


### PR DESCRIPTION
## Description of the change

See https://github.com/merge-api/react-merge-link/pull/28.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)