### PR TITLE
Add onValidationError callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,13 +2,23 @@ export type AdditionalSuccessfulLinkInfo = {
   isTokenForOtherPreexistingLinkedAccount?: boolean;
 };
 
+export type ValidationErrors = ValidationError[];
+
+export type ValidationError = {
+  detail: string;
+  problem_type?: string;
+  error_response?: string;
+  [key: string]: any;
+};
+
 export interface MergeLink {
   initialize: (config: InitializeProps) => void;
   update: (config: {
     linkToken: string;
+    onValidationError?: (errors: ValidationErrors) => void;
     onSuccess: (
       publicToken: string,
-      additionalInfo?: AdditionalSuccessfulLinkInfo
+      additionalInfo?: AdditionalSuccessfulLinkInfo,
     ) => void;
   }) => void;
   openLink: (config: UseMergeLinkProps) => void;
@@ -20,9 +30,10 @@ export interface TenantConfig {
 export interface UseMergeLinkProps {
   linkToken?: string | undefined;
   tenantConfig?: TenantConfig;
+  onValidationError?: (errors: ValidationErrors) => void;
   onSuccess: (
     publicToken: string,
-    additionalInfo?: AdditionalSuccessfulLinkInfo
+    additionalInfo?: AdditionalSuccessfulLinkInfo,
   ) => void;
   onExit?: () => void;
   /**

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,7 +7,6 @@ export type ValidationErrors = ValidationError[];
 export type ValidationError = {
   detail: string;
   problem_type?: string;
-  error_response?: string;
   [key: string]: any;
 };
 
@@ -18,7 +17,7 @@ export interface MergeLink {
     onValidationError?: (errors: ValidationErrors) => void;
     onSuccess: (
       publicToken: string,
-      additionalInfo?: AdditionalSuccessfulLinkInfo,
+      additionalInfo?: AdditionalSuccessfulLinkInfo
     ) => void;
   }) => void;
   openLink: (config: UseMergeLinkProps) => void;
@@ -33,7 +32,7 @@ export interface UseMergeLinkProps {
   onValidationError?: (errors: ValidationErrors) => void;
   onSuccess: (
     publicToken: string,
-    additionalInfo?: AdditionalSuccessfulLinkInfo,
+    additionalInfo?: AdditionalSuccessfulLinkInfo
   ) => void;
   onExit?: () => void;
   /**


### PR DESCRIPTION
## Description of the change

Add callback for `onValidationError` defined in merge-link

link callback pr: https://github.com/merge-api/merge-link/pull/410

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://app.asana.com/0/1202262938305017/1203303915762327/f

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
