### PR TITLE
Adding parent container ID to props and typing file picker props right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -24,7 +24,7 @@ export interface MergeLink {
 }
 
 export type MergeFileStorageData = {
-  type?: FilePickerObjectType;
+  outputType?: FilePickerObjectType;
   id: string;
   name?: string;
   description?: string;
@@ -71,6 +71,10 @@ export interface UseMergeLinkProps {
    * Passing this optional input into useMergeLink will allow users to use the File Picker
    */
   filePickerConfig?: FilePickerConfig;
+  /**
+   * Passing this allows users to target a specific element in their page to embed link under (eg for modals)
+   */
+  parentContainerID?: string;
 }
 
 export interface InitializeProps extends UseMergeLinkProps {


### PR DESCRIPTION
## Description of the change

As title - changing type of output of file picker props to outputType to match return without breaking changes and adding optional parentContainer ID Prop


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> All PRs at Merge must be backed by an Asana ticket (except Develop -> Master PRs). Create one here, and then replace this line with the link. https://app.asana.com/0/1198991781422585/list

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
