### PR TITLE
fix: replace @ts-ignore with proper TypeScript typing in useScript

### DIFF
--- a/src/hooks/useScript.tsx
+++ b/src/hooks/useScript.tsx
@@ -85,12 +85,10 @@ export default function useScript({
       scriptEl.src = src;
 
       Object.keys(attributes).forEach((key) => {
-        // @ts-ignore
-        if (scriptEl[key] === undefined) {
+        if (!(key in scriptEl)) {
           scriptEl.setAttribute(key, attributes[key]);
         } else {
-          // @ts-ignore
-          scriptEl[key] = attributes[key];
+          (scriptEl as any)[key] = attributes[key];
         }
       });
 


### PR DESCRIPTION
# fix: replace @ts-ignore with proper TypeScript typing in useScript

## Summary
Replaced problematic `@ts-ignore` comments in the useScript hook with proper TypeScript typing. The changes improve type safety while maintaining the same functionality for setting attributes on HTMLScriptElement objects.

**Key changes:**
- Replace `@ts-ignore` with explicit `(scriptEl as any)` type assertion 
- Improve property existence check from `scriptEl[key] === undefined` to `!(key in scriptEl)`
- Eliminate TypeScript linting violations while preserving runtime behavior

## Review & Testing Checklist for Human
- [ ] **Verify attribute setting logic**: Test that both `setAttribute()` and direct property assignment paths work correctly with real script attributes (e.g., `async`, `defer`, `crossorigin`)
- [ ] **Check property existence logic**: Confirm that `!(key in scriptEl)` behaves identically to `scriptEl[key] === undefined` for HTMLScriptElement properties - this is the main behavioral change
- [ ] **Test end-to-end**: Verify that scripts load correctly with various attribute combinations in a real browser environment

### Notes
- The explicit `as any` cast is more transparent than `@ts-ignore` but still bypasses type safety for this specific line
- Build and TypeScript compilation pass successfully
- This change addresses TypeScript linting violations identified during code review

---
**Link to Devin run:** https://app.devin.ai/sessions/b3abc6bba0d74c31a560e682d6617bfc  
**Requested by:** @hmafzal