### PR TITLE
Adds DBX CDN link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -18,6 +18,8 @@ const BASE_URL_TO_CDN_MAP: Record<string, string> = {
     'https://cdn.openaimerge.com/initialize.js',
   'https://api-develop.merge.dev':
     'https://develop-cdn.merge.dev/initialize.js',
+  'https://api-usw2.dropboxmerge.com':
+    'https://cdn.dropboxmerge.com/initialize.js',
 };
 
 const isLinkTokenDefined = (


### PR DESCRIPTION
## Description of the change

Adds the DBX single-tenant API base URLs to the CDN lookup map so merge-link loads from cdn.dropboxmerge.com instead of falling back to cdn.merge.dev.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> All PRs at Merge must be backed by an Asana ticket (except Develop -> Master PRs). Create one here, and then replace this line with the link. https://app.asana.com/0/1198991781422585/list

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
