### PR TITLE
Adding OAI APNE2 CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -16,6 +16,8 @@ const BASE_URL_TO_CDN_MAP: Record<string, string> = {
     'https://cdn.openaimerge.com/initialize.js',
   'https://api-oai-apne3.openaimerge.com':
     'https://cdn.openaimerge.com/initialize.js',
+  'https://api-oai-apne2.openaimerge.com':
+    'https://cdn.openaimerge.com/initialize.js',
   'https://api-develop.merge.dev':
     'https://develop-cdn.merge.dev/initialize.js',
   'https://api-mu-develop.merge.dev':


### PR DESCRIPTION
## Description of the change

Adds the OAI-APNE2 single-tenant API base URLs to the CDN lookup map so merge-link loads from cdn.openaimerge.com instead of falling back to cdn.merge.dev, which causes CORS errors in the linking flow.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://app.asana.com/1/1174208460831550/task/1216538624142423?focus=true

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
