### PR TITLE
Add OAI apse2 tenant CDN mapping; bump to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/react-merge-link",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A React hook wrapper for Merge Link.",
   "files": [
     "dist",

--- a/src/useMergeLink.tsx
+++ b/src/useMergeLink.tsx
@@ -18,6 +18,8 @@ const BASE_URL_TO_CDN_MAP: Record<string, string> = {
     'https://cdn.openaimerge.com/initialize.js',
   'https://api-oai-apne2.openaimerge.com':
     'https://cdn.openaimerge.com/initialize.js',
+  'https://api-oai-apse2.openaimerge.com':
+    'https://cdn.openaimerge.com/initialize.js',
   'https://api-develop.merge.dev':
     'https://develop-cdn.merge.dev/initialize.js',
   'https://api-mu-develop.merge.dev':


### PR DESCRIPTION
## What

Adds the ap-southeast-2 OpenAI single-tenant to the SDK's CDN map.

- `src/useMergeLink.tsx` — `BASE_URL_TO_CDN_MAP`: map `https://api-oai-apse2.openaimerge.com` → `https://cdn.openaimerge.com/initialize.js` (matching the other OAI tenants)
- `package.json` — bump version `2.4.0` → `2.4.1`

## Release / ordering

This is a published npm package. After merge, **publish `2.4.1` to npm** (manual `npm publish` by a maintainer). Only then can the dependents bump:

🤖 Generated with [Claude Code](https://claude.com/claude-code)